### PR TITLE
ux: Add a "Clear Cache" developer utility button in the footer (#78)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,13 +4,31 @@ import React from "react";
 import { ExternalLink } from "lucide-react";
 
 export default function Footer() {
+  const handleClearCache = () => {
+    localStorage.clear();
+    sessionStorage.clear(); // Good measure for QA
+    alert("App data cleared. Please refresh the page.");
+  };
+
   return (
     <footer className="bg-slate-800 border-t border-slate-700 py-8 px-8 mt-auto">
       <div className="max-w-7xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-          <div className="text-slate-400 text-sm">
-            © 2024 TradeFlow. All rights reserved.
+
+          <div className="flex items-center gap-4">
+            <span className="text-slate-400 text-sm">
+              © 2024 TradeFlow. All rights reserved.
+            </span>
+            {/* Developer QA Utility */}
+            <button
+              onClick={handleClearCache}
+              className="text-slate-600 hover:text-slate-400 transition-colors text-xs"
+              title="Clear Local Storage & Cache"
+            >
+              Clear Cache
+            </button>
           </div>
+
           <nav className="flex gap-6">
             <a
               href="#"
@@ -44,10 +62,12 @@ export default function Footer() {
               <ExternalLink size={12} className="w-4 h-4" />
             </a>
           </nav>
+
           <div className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full bg-emerald-500 shadow-lg shadow-emerald-500/50"></div>
             <span className="text-slate-400 text-sm">Systems Operational</span>
           </div>
+
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Description
This PR resolves Issue #78 by introducing a subtle "Clear Cache" utility button to the application footer. 

During heavy QA testing and Beta usage, stale local storage can often cause UI desyncs or display outdated risk metrics. Instead of forcing testers to manually open browser DevTools to wipe their local storage, they can now quickly reset their application state using this discreet button. 

**Key Additions:**
- Added a `handleClearCache` function to `Footer.tsx` that wipes `localStorage` and `sessionStorage`.
- Appended a UI button next to the copyright text, styled with `text-slate-600` to ensure it remains hidden from standard users but accessible to developers/QA.
- Included the requested browser `alert()` prompting the user to refresh the page after the cache is wiped.

Closes #78

## Type of Change
- [x] UX Improvement
- [x] Developer/QA Tooling

## Validation
- [x] Verified button seamlessly blends into the footer without disrupting the layout.
- [x] Verified clicking the button successfully empties local browser storage.
- [x] Verified the alert properly triggers post-clear.