### PR TITLE
feat: Add reusable empty state component and related SVG illustrations

### DIFF
--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface EmptyStateProps {
+  /** The main title for the empty state. */
+  title: string;
+  /** A more detailed description. */
+  description: string;
+  /** The SVG icon or illustration component. */
+  icon: React.ReactNode;
+  /** An optional call-to-action element, like a button. */
+  callToAction?: React.ReactNode;
+}
+
+/**
+ * A reusable component for displaying empty states in the application.
+ * It's designed to be used when a list, table, or content area has no data to show.
+ */
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  description,
+  icon,
+  callToAction,
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center space-y-4 rounded-lg border-2 border-dashed border-slate-200 p-12 text-center dark:border-slate-800">
+      <div className="text-slate-400 dark:text-slate-600">{icon}</div>
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+          {title}
+        </h2>
+        <p className="max-w-sm text-sm text-slate-500 dark:text-slate-400">
+          {description}
+        </p>
+      </div>
+      {callToAction && <div className="pt-4">{callToAction}</div>}
+    </div>
+  );
+};

--- a/src/lib/no-activity-illustration.tsx
+++ b/src/lib/no-activity-illustration.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * SVG Illustration for when there is no activity or transaction history.
+ * Inherits color from parent for dark/light mode compatibility.
+ */
+export const NoActivityIllustration = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="128"
+    height="128"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M3 3v18h18" />
+    <path d="M7 12h10" />
+  </svg>
+);

--- a/src/lib/no-invoices-illustration.tsx
+++ b/src/lib/no-invoices-illustration.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/**
+ * SVG Illustration for when there are no invoices to display.
+ * Inherits color from parent for dark/light mode compatibility.
+ */
+export const NoInvoicesIllustration = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="128"
+    height="128"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+    <polyline points="14 2 14 8 20 8" />
+    <circle cx="11.5" cy="14.5" r="2.5" />
+    <path d="M13.25 16.25L15 18" />
+  </svg>
+);

--- a/src/lib/no-search-results-illustration.tsx
+++ b/src/lib/no-search-results-illustration.tsx
@@ -1,0 +1,24 @@
+port React from 'react';
+
+/**
+ * SVG Illustration for when a search yields no results.
+ * Inherits color from parent for dark/light mode compatibility.
+ */
+export const NoSearchResultsIllustration = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="128"
+    height="128"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    <line x1="13" y1="9" x2="9" y2="13" />
+    <line x1="9" y1="9" x2="13" y2="13" />
+  </svg>
+);


### PR DESCRIPTION
Feat: Implement reusable Empty State component

Resolves #212

This PR introduces a reusable EmptyState component and a set of SVG illustrations to improve the user experience on pages where no data is present. Instead of showing blank tables or content areas, these components provide visual guidance and a more polished look.

Changes Included:

SVG Illustrations: Added three new SVG components (NoInvoicesIllustration, NoActivityIllustration, NoSearchResultsIllustration) that adapt to light/dark mode using currentColor.
Reusable EmptyState Component: Created a new component at src/components/ui/empty-state.tsx. It accepts a title, description, icon, and an optional callToAction element, making it easy to implement consistent empty states across the application.
