### PR TITLE
feat: refactor raw SVGs into reusable icon components

### DIFF
--- a/src/components/AuthenticatedSkeleton.tsx
+++ b/src/components/AuthenticatedSkeleton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { ChevronDownIcon } from "./icons";
 import { Wallet, Loader2 } from "lucide-react";
 
 interface AuthenticatedSkeletonProps {
@@ -44,9 +45,7 @@ export default function AuthenticatedSkeleton({
       
       {/* Dropdown Arrow */}
       <div className="w-4 h-4 text-slate-400">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M6 9l6 6 6-6" />
-        </svg>
+        <ChevronDownIcon />
       </div>
     </div>
   );

--- a/src/components/WalletModal.tsx
+++ b/src/components/WalletModal.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { FREIGHTER_ID, XBULL_ID, ALBEDO_ID, WalletType } from "../lib/stellar";
 import { getWalletDisplayName, getWalletDescription, getWalletIcon, getWalletBgColor } from "../lib/walletConnector";
+import { CloseIcon } from "./icons";
 
 interface WalletModalProps {
   isOpen: boolean;
@@ -59,19 +60,7 @@ export default function WalletModal({ isOpen, onClose, onConnect }: WalletModalP
             onClick={onClose}
             className="text-slate-400 hover:text-white transition-colors"
           >
-            <svg
-              className="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+            <CloseIcon />
           </button>
         </div>
 

--- a/src/components/WalletNotConnected.tsx
+++ b/src/components/WalletNotConnected.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { WalletIcon } from "./icons";
 
 interface WalletNotConnectedProps {
   onConnect?: () => void;
@@ -20,54 +21,7 @@ export default function WalletNotConnected({
         />
         {/* Icon container */}
         <div className="relative flex items-center justify-center w-28 h-28 rounded-3xl bg-white/5 border border-white/10 shadow-xl">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 64 64"
-            fill="none"
-            className="w-14 h-14"
-            aria-hidden="true"
-          >
-            {/* Wallet body */}
-            <rect
-              x="4"
-              y="16"
-              width="56"
-              height="36"
-              rx="6"
-              stroke="#60a5fa"
-              strokeWidth="2.5"
-              fill="none"
-            />
-            {/* Wallet flap */}
-            <path
-              d="M4 26h56"
-              stroke="#60a5fa"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-            />
-            {/* Card slot */}
-            <path
-              d="M8 16v-3a4 4 0 0 1 4-4h40a4 4 0 0 1 4 4v3"
-              stroke="#60a5fa"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              fill="none"
-            />
-            {/* Coin pocket */}
-            <rect
-              x="40"
-              y="31"
-              width="14"
-              height="10"
-              rx="5"
-              fill="#60a5fa"
-              fillOpacity="0.15"
-              stroke="#60a5fa"
-              strokeWidth="2"
-            />
-            {/* Coin dot */}
-            <circle cx="47" cy="36" r="2" fill="#93c5fd" />
-          </svg>
+          <WalletIcon className="w-14 h-14" />
         </div>
       </div>
 

--- a/src/components/icons/ArrowUpIcon.tsx
+++ b/src/components/icons/ArrowUpIcon.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface ArrowUpIconProps {
+  className?: string;
+}
+
+export default function ArrowUpIcon({ className = "h-6 w-6" }: ArrowUpIconProps) {
+  return (
+    <svg 
+      xmlns="http://www.w3.org/2000/svg" 
+      fill="none" 
+      viewBox="0 0 24 24" 
+      strokeWidth={2.5} 
+      stroke="currentColor" 
+      className={className}
+    >
+      <path 
+        strokeLinecap="round" 
+        strokeLinejoin="round" 
+        d="M4.5 15.75l7.5-7.5 7.5 7.5" 
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/ChevronDownIcon.tsx
+++ b/src/components/icons/ChevronDownIcon.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface ChevronDownIconProps {
+  className?: string;
+}
+
+export default function ChevronDownIcon({ className = "w-4 h-4" }: ChevronDownIconProps) {
+  return (
+    <svg 
+      viewBox="0 0 24 24" 
+      fill="none" 
+      stroke="currentColor" 
+      strokeWidth="2"
+      className={className}
+    >
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  );
+}

--- a/src/components/icons/CloseIcon.tsx
+++ b/src/components/icons/CloseIcon.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface CloseIconProps {
+  className?: string;
+}
+
+export default function CloseIcon({ className = "w-6 h-6" }: CloseIconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M6 18L18 6M6 6l12 12"
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/IconTest.tsx
+++ b/src/components/icons/IconTest.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { WalletIcon, CloseIcon, ArrowUpIcon, ChevronDownIcon } from "./index";
+
+export default function IconTest() {
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Icon Test Component</h1>
+      
+      <div className="flex items-center space-x-4">
+        <div className="text-center">
+          <WalletIcon className="w-8 h-8 mb-2" />
+          <p className="text-sm">WalletIcon</p>
+        </div>
+        
+        <div className="text-center">
+          <CloseIcon className="w-8 h-8 mb-2" />
+          <p className="text-sm">CloseIcon</p>
+        </div>
+        
+        <div className="text-center">
+          <ArrowUpIcon className="w-8 h-8 mb-2" />
+          <p className="text-sm">ArrowUpIcon</p>
+        </div>
+        
+        <div className="text-center">
+          <ChevronDownIcon className="w-8 h-8 mb-2" />
+          <p className="text-sm">ChevronDownIcon</p>
+        </div>
+      </div>
+      
+      <div className="mt-8 p-4 bg-green-100 border border-green-300 rounded">
+        <p className="text-green-800">✅ All icons are properly exported and can be imported!</p>
+        <p className="text-green-600 text-sm mt-2">
+          Each icon accepts a className prop for custom styling with Tailwind CSS.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/icons/WalletIcon.tsx
+++ b/src/components/icons/WalletIcon.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+interface WalletIconProps {
+  className?: string;
+}
+
+export default function WalletIcon({ className = "" }: WalletIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 64 64"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* Wallet body */}
+      <rect
+        x="4"
+        y="16"
+        width="56"
+        height="36"
+        rx="6"
+        stroke="#60a5fa"
+        strokeWidth="2.5"
+        fill="none"
+      />
+      {/* Wallet flap */}
+      <path
+        d="M4 26h56"
+        stroke="#60a5fa"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      {/* Card slot */}
+      <path
+        d="M8 16v-3a4 4 0 0 1 4-4h40a4 4 0 0 1 4 4v3"
+        stroke="#60a5fa"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        fill="none"
+      />
+      {/* Coin pocket */}
+      <rect
+        x="40"
+        y="31"
+        width="14"
+        height="10"
+        rx="5"
+        fill="#60a5fa"
+        fillOpacity="0.15"
+        stroke="#60a5fa"
+        strokeWidth="2"
+      />
+      {/* Coin dot */}
+      <circle cx="47" cy="36" r="2" fill="#93c5fd" />
+    </svg>
+  );
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,0 +1,4 @@
+export { default as WalletIcon } from './WalletIcon';
+export { default as CloseIcon } from './CloseIcon';
+export { default as ArrowUpIcon } from './ArrowUpIcon';
+export { default as ChevronDownIcon } from './ChevronDownIcon';

--- a/src/components/ui/ScrollToTop.tsx
+++ b/src/components/ui/ScrollToTop.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from 'react';
+import { ArrowUpIcon } from "../icons";
 
 export const ScrollToTop: React.FC = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -37,9 +38,7 @@ export const ScrollToTop: React.FC = () => {
       className="fixed bottom-8 right-8 z-50 flex items-center justify-center rounded-full bg-blue-600 p-3 text-white shadow-lg transition-all hover:bg-blue-700 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-slate-900"
       aria-label="Scroll to top"
     >
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="h-6 w-6">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
-      </svg>
+      <ArrowUpIcon />
     </button>
   );
 };


### PR DESCRIPTION
Closes #82

---

- Create components/icons/ directory for centralized icon management
- Extract 4 icons: WalletIcon, CloseIcon, ArrowUpIcon, ChevronDownIcon
- Replace raw SVGs in WalletNotConnected, WalletModal, ScrollToTop, and AuthenticatedSkeleton
- Add TypeScript interfaces and className props for Tailwind CSS compatibility
- Create index.ts for clean imports
- Improve code readability and maintainability across the app