### PR TITLE
Create a detailed Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Description
+
+Closes #[ISSUE_NUMBER]
+
+<!-- Briefly describe the changes made and why -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would break existing functionality)
+- [ ] Refactor (code improvement without functional changes)
+- [ ] Documentation update
+
+## Testing Strategy
+
+<!-- Describe how you tested your changes. Include steps to reproduce, test commands, or manual testing flow. -->
+
+- [ ] I have run the linter and type checker
+- [ ] I have added/updated tests
+- [ ] All existing tests pass
+
+## Self-Review Checklist
+
+- [ ] My code follows the project's coding style
+- [ ] I have reviewed my own code for potential issues
+- [ ] I have added necessary documentation/comments
+- [ ] I have updated relevant README or docs if needed
+- [ ] No new warnings or errors are introduced
+- [ ] Changes are backward-compatible (or documented breaking changes)


### PR DESCRIPTION
Closes #260

## Description
Adds a standardized pull request template that auto-populates when opening a PR.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation update

## Changes
- Created `.github/pull_request_template.md` with sections for:
  - Description (linking back to the original issue)
  - Type of Change checklist
  - Testing Strategy
  - Self-Review Checklist