### PR TITLE
docs(268): add ADR template and first real ADR for App Router decision

### DIFF
--- a/docs/ADR/0000-template.md
+++ b/docs/ADR/0000-template.md
@@ -1,0 +1,30 @@
+# 0000. Title of Decision
+
+Date: YYYY-MM-DD
+
+## Status
+
+Proposed | Accepted | Superseded by [ADR-XXXX](./XXXX-title.md)
+
+## Context
+
+What is the issue we're seeing that motivates this decision? Describe the
+forces at play (technical, business, team-related) without yet committing
+to a solution.
+
+## Decision
+
+What is the change we're proposing/have agreed to? State it clearly and
+in active voice ("We will use...").
+
+## Consequences
+
+What becomes easier or harder as a result of this decision? Include both
+positive and negative outcomes, and any follow-up work created.
+
+## Alternatives Considered
+
+What other options were evaluated, and why were they not chosen?
+
+- **Alternative A** — why rejected
+- **Alternative B** — why rejected

--- a/docs/ADR/0001-use-nextjs-app-router.md
+++ b/docs/ADR/0001-use-nextjs-app-router.md
@@ -1,0 +1,43 @@
+# 0001. Use Next.js App Router
+
+Date: 2026-06-19
+
+## Status
+
+Accepted
+
+## Context
+
+TradeFlow-Web needs server-side rendering for SEO on public dashboard
+pages, streaming support for real-time risk analytics data, and a routing
+model that scales as the number of dashboard views grows (invoices,
+risk analytics, contract interactions). Next.js offers two routing
+paradigms: the legacy Pages Router and the newer App Router.
+
+## Decision
+
+We will use the Next.js App Router (`src/app/`) instead of the Pages
+Router for all routing in TradeFlow-Web.
+
+## Consequences
+
+- We gain native support for React Server Components, reducing client
+  bundle size for data-heavy dashboard views.
+- Layouts and nested routing simplify shared UI (e.g. wallet connection
+  state) across dashboard sections.
+- Streaming and `loading.tsx` conventions improve perceived performance
+  for risk analytics fetches.
+- The team must use App Router-specific patterns (e.g. `"use client"`
+  boundaries) for Freighter wallet integration, which only works
+  client-side.
+- Some older Next.js tutorials/libraries assume the Pages Router and
+  require adaptation.
+
+## Alternatives Considered
+
+- **Pages Router** — simpler mental model and more mature ecosystem
+  support, but lacks Server Components and has weaker support for
+  streaming and nested layouts, which we need for the dashboard.
+- **Separate Express API + SPA frontend** — more deployment overhead
+  and duplicated routing/auth logic; rejected in favor of using Next.js
+  API routes/Route Handlers directly (see future ADR if this changes).


### PR DESCRIPTION
## Summary
Closes #268

Introduces a standard ADR (Architecture Decision Record) format so future
major technical decisions (e.g. "why Zustand over Redux") are documented
and discoverable, instead of living only in PR discussions or Slack history.

## Changes
- Created `docs/ADR/` directory
- Added `docs/ADR/0000-template.md` — the reusable template with required
  sections: **Context**, **Decision**, **Consequences**, **Alternatives
  Considered**
- Added `docs/ADR/0001-use-nextjs-app-router.md` — the first real ADR,
  documenting why the project uses the Next.js App Router instead of the
  Pages Router, as a worked example for the team

## Why
In 6 months, no one will remember why we chose the App Router over the
Pages Router, or why certain alternatives were rejected. ADRs give us a
permanent, lightweight record of the reasoning behind major decisions.

## Convention going forward
- ADRs are **immutable** once merged. If a decision changes, a new ADR is
  written that supersedes the old one (the old ADR's Status is updated to
  "Superseded by ADR-XXXX", but its content is not rewritten).
- Numbering is sequential: `0002-...`, `0003-...`, etc.

## Testing
- [x] Verified `0000-template.md` follows the acceptance criteria's required
      sections exactly
- [x] Verified `0001-use-nextjs-app-router.md` renders correctly as Markdown
      on GitHub (checked formatting, headers, code spans)

## Notes for reviewer
- Open to feedback on the exact wording of ADR-0001 if anyone involved in
  the original App Router decision wants to refine the Context/Alternatives
  sections with more specific historical detail.