### PR TITLE
fix(242): replace sessionStorage JWT with HttpOnly secure cookies

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,36 +1,38 @@
 require("@testing-library/jest-dom");
 
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: jest.fn().mockImplementation((query) => ({
-    matches: query === "(prefers-color-scheme: dark)",
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: query === "(prefers-color-scheme: dark)",
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
 
-const localStorageMock = (() => {
-  let store = {};
-  return {
-    getItem: jest.fn((key) => store[key] ?? null),
-    setItem: jest.fn((key, value) => {
-      store[key] = value;
-    }),
-    removeItem: jest.fn((key) => {
-      delete store[key];
-    }),
-    clear: jest.fn(() => {
-      store = {};
-    }),
-  };
-})();
+  const localStorageMock = (() => {
+    let store = {};
+    return {
+      getItem: jest.fn((key) => store[key] ?? null),
+      setItem: jest.fn((key, value) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn((key) => {
+        delete store[key];
+      }),
+      clear: jest.fn(() => {
+        store = {};
+      }),
+    };
+  })();
 
-Object.defineProperty(window, "localStorage", {
-  writable: true,
-  value: localStorageMock,
-});
+  Object.defineProperty(window, "localStorage", {
+    writable: true,
+    value: localStorageMock,
+  });
+}

--- a/src/app/api/auth/__tests__/route.test.ts
+++ b/src/app/api/auth/__tests__/route.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from "next/server";
+import { POST, DELETE } from "../route";
+
+function makeRequest(body: unknown, method = "POST"): NextRequest {
+  return new NextRequest("http://localhost/api/auth", {
+    method,
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/auth", () => {
+  test("returns 200 and sets HttpOnly cookie for a valid token", async () => {
+    const req = makeRequest({ token: "eyJhbGciOiJIUzI1NiJ9.test" });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).not.toBeNull();
+    expect(setCookie).toContain("tradeflow_auth_token=");
+    expect(setCookie?.toLowerCase()).toContain("httponly");
+    expect(setCookie?.toLowerCase()).toContain("samesite=strict");
+    expect(setCookie?.toLowerCase()).toContain("path=/");
+  });
+
+  test("returns 400 when token is missing", async () => {
+    const req = makeRequest({});
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toBe("Missing token");
+  });
+
+  test("returns 400 when token is an empty string", async () => {
+    const req = makeRequest({ token: "   " });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toBe("Missing token");
+  });
+
+  test("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/auth", {
+      method: "POST",
+      body: "not-json",
+      headers: { "Content-Type": "text/plain" },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toBe("Invalid JSON body");
+  });
+});
+
+describe("DELETE /api/auth", () => {
+  test("returns 200 and expires the auth cookie", async () => {
+    const req = new NextRequest("http://localhost/api/auth", { method: "DELETE" });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).not.toBeNull();
+    expect(setCookie).toContain("tradeflow_auth_token=");
+    // maxAge=0 causes the browser to immediately expire/delete the cookie
+    expect(setCookie?.toLowerCase()).toContain("max-age=0");
+  });
+});

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const COOKIE_NAME = "tradeflow_auth_token";
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "strict" as const,
+  path: "/",
+  // 24-hour session lifetime
+  maxAge: 60 * 60 * 24,
+};
+
+/**
+ * POST /api/auth
+ * Accepts a JWT in the request body and sets it as a secure HttpOnly cookie.
+ * The cookie is inaccessible to JavaScript, eliminating XSS token theft.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let token: string | undefined;
+
+  try {
+    const body = await request.json();
+    token = typeof body?.token === "string" ? body.token.trim() : undefined;
+  } catch {
+    return NextResponse.json({ error: { message: "Invalid JSON body" } }, { status: 400 });
+  }
+
+  if (!token) {
+    return NextResponse.json({ error: { message: "Missing token" } }, { status: 400 });
+  }
+
+  const response = NextResponse.json({ ok: true }, { status: 200 });
+  response.cookies.set(COOKIE_NAME, token, COOKIE_OPTIONS);
+  return response;
+}
+
+/**
+ * DELETE /api/auth
+ * Clears the auth cookie, effectively logging the user out.
+ */
+export async function DELETE(_request: NextRequest): Promise<NextResponse> {
+  const response = NextResponse.json({ ok: true }, { status: 200 });
+  response.cookies.set(COOKIE_NAME, "", { ...COOKIE_OPTIONS, maxAge: 0 });
+  return response;
+}

--- a/src/lib/__tests__/httpClient.test.ts
+++ b/src/lib/__tests__/httpClient.test.ts
@@ -1,0 +1,83 @@
+import { createHttpClient, normalizeHttpError } from "../httpClient";
+import axios from "axios";
+
+jest.mock("../env", () => ({
+  getApiBaseUrl: () => "http://localhost:3001",
+}));
+
+function mockAdapter(client: ReturnType<typeof createHttpClient>) {
+  let capturedHeaders: Record<string, string> = {};
+  client.defaults.adapter = async (config: any) => {
+    capturedHeaders = Object.fromEntries(
+      Object.entries((config.headers as Record<string, unknown>) ?? {})
+        .filter(([, v]) => typeof v === "string")
+        .map(([k, v]) => [k, v as string]),
+    );
+    return { data: {}, status: 200, statusText: "OK", headers: {}, config };
+  };
+  return () => capturedHeaders;
+}
+
+describe("createHttpClient", () => {
+  test("sets withCredentials: true so HttpOnly cookies are sent automatically", () => {
+    const client = createHttpClient();
+    expect((client.defaults as any).withCredentials).toBe(true);
+  });
+
+  test("uses the provided baseURL override", () => {
+    const client = createHttpClient({ baseURL: "http://custom-api.test" });
+    expect(client.defaults.baseURL).toBe("http://custom-api.test");
+  });
+
+  test("uses the provided timeout override", () => {
+    const client = createHttpClient({ timeoutMs: 5000 });
+    expect(client.defaults.timeout).toBe(5000);
+  });
+
+  test("sets X-Requested-With header via interceptor", async () => {
+    const client = createHttpClient();
+    const getHeaders = mockAdapter(client);
+
+    await client.get("/test");
+
+    expect(getHeaders()["X-Requested-With"]).toBe("XMLHttpRequest");
+  });
+
+  test("does not set an Authorization header", async () => {
+    const client = createHttpClient();
+    const getHeaders = mockAdapter(client);
+
+    await client.get("/test");
+
+    expect(getHeaders()["Authorization"]).toBeUndefined();
+  });
+});
+
+describe("normalizeHttpError", () => {
+  test("returns unknown error message for non-Axios errors", () => {
+    const result = normalizeHttpError(new Error("boom"));
+    expect(result.error.message).toBe("boom");
+    expect(result.status).toBeUndefined();
+  });
+
+  test("extracts status and message from Axios errors", () => {
+    const axiosErr = Object.assign(new Error("Request failed"), {
+      isAxiosError: true,
+      response: {
+        status: 503,
+        data: { error: { message: "service unavailable" } },
+        headers: { "content-type": "application/json" },
+      },
+    });
+    jest.spyOn(axios, "isAxiosError").mockReturnValueOnce(true);
+
+    const result = normalizeHttpError(axiosErr);
+    expect(result.status).toBe(503);
+    expect(result.error.message).toBe("service unavailable");
+  });
+
+  test("falls back gracefully for non-Error unknowns", () => {
+    const result = normalizeHttpError("string error");
+    expect(result.error.message).toBe("Unknown error");
+  });
+});

--- a/src/lib/__tests__/riskSocket.test.ts
+++ b/src/lib/__tests__/riskSocket.test.ts
@@ -4,9 +4,6 @@ jest.mock("../env", () => ({
   getWsBaseUrl: () => "ws://localhost:1234",
 }));
 
-jest.mock("../httpClient", () => ({
-  getAuthToken: () => "test-token",
-}));
 
 class MockWebSocket {
   static instances: MockWebSocket[] = [];
@@ -45,13 +42,14 @@ describe("RiskSocketClient", () => {
     (global as any).WebSocket = MockWebSocket;
   });
 
-  test("connect appends token and resubscribes invoice rooms on open", () => {
+  test("connect does not expose token in URL and resubscribes invoice rooms on open", () => {
     const client = new RiskSocketClient();
     client.connect();
 
     expect(MockWebSocket.instances).toHaveLength(1);
     const ws = MockWebSocket.instances[0]!;
-    expect(ws.url).toContain("token=test-token");
+    // Token must not appear in the WebSocket URL — auth is handled via HttpOnly cookie
+    expect(ws.url).not.toContain("token=");
 
     client.subscribeInvoice("INV-1");
 

--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -9,60 +9,6 @@ import axios, {
 import { getApiBaseUrl } from "./env";
 import type { ApiErrorDetails, ApiStatusCode } from "../../types/api";
 
-const AUTH_TOKEN_STORAGE_KEY = "tradeflow_auth_token";
-
-let inMemoryAuthToken: string | null = null;
-
-export interface SetAuthTokenOptions {
-  persist?: "memory" | "session";
-}
-
-/**
- * Stores the auth token in memory and optionally in sessionStorage.
- * @param token - The token to store, or null to clear.
- * @param options - Persistence strategy (memory or session).
- */
-export function setAuthToken(token: string | null, options: SetAuthTokenOptions = {}): void {
-  const { persist = "session" } = options;
-  inMemoryAuthToken = token;
-
-  if (typeof window === "undefined") return;
-
-  try {
-    if (persist === "session") {
-      if (token) window.sessionStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
-      else window.sessionStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
-    } else {
-      if (!token) window.sessionStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
-    }
-  } catch {
-    return;
-  }
-}
-
-/**
- * Retrieves the stored auth token from memory or sessionStorage.
- * @returns The auth token string, or null.
- */
-export function getAuthToken(): string | null {
-  if (inMemoryAuthToken) return inMemoryAuthToken;
-  if (typeof window === "undefined") return null;
-
-  try {
-    const token = window.sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
-    return token || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Clears the stored auth token from memory and sessionStorage.
- */
-export function clearAuthToken(): void {
-  setAuthToken(null);
-}
-
 export interface HttpClientOptions {
   baseURL?: string;
   timeoutMs?: number;
@@ -171,8 +117,9 @@ export function normalizeHttpError(error: unknown): {
 }
 
 /**
- * Creates a configured Axios instance with auth interceptors, retry logic,
- * and JSON response transformation.
+ * Creates a configured Axios instance with cookie-based auth, retry logic,
+ * and JSON response transformation. withCredentials ensures the browser
+ * automatically attaches the HttpOnly auth cookie on every request.
  * @param options - Optional overrides for base URL, timeout, and retries.
  * @returns A configured AxiosInstance.
  */
@@ -184,6 +131,7 @@ export function createHttpClient(options: HttpClientOptions = {}): AxiosInstance
   const instance = axios.create({
     baseURL,
     timeout,
+    withCredentials: true,
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
@@ -204,19 +152,10 @@ export function createHttpClient(options: HttpClientOptions = {}): AxiosInstance
   });
 
   instance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
-    const token = getAuthToken();
-    if (token) {
-      if (!config.headers) {
-        config.headers = new AxiosHeaders();
-      }
-      config.headers.set("Authorization", `Bearer ${token}`);
-    }
-
     if (!config.headers) {
       config.headers = new AxiosHeaders();
     }
     config.headers.set("X-Requested-With", "XMLHttpRequest");
-
     return config;
   });
 

--- a/src/lib/riskSocket.ts
+++ b/src/lib/riskSocket.ts
@@ -1,5 +1,4 @@
 import { getWsBaseUrl } from "./env";
-import { getAuthToken } from "./httpClient";
 
 export interface RiskUpdateEvent {
   invoiceId: string;
@@ -14,7 +13,6 @@ export type RiskSocketEvent =
 
 export interface RiskSocketClientOptions {
   wsBaseUrl?: string;
-  token?: string | null;
 }
 
 type Listener = (event: RiskSocketEvent) => void;
@@ -29,11 +27,9 @@ export class RiskSocketClient {
   private riskFeedEnabled = false;
 
   private wsBaseUrl: string;
-  private token: string | null;
 
   constructor(options: RiskSocketClientOptions = {}) {
     this.wsBaseUrl = options.wsBaseUrl ?? getWsBaseUrl();
-    this.token = options.token ?? getAuthToken();
   }
 
   /**
@@ -63,18 +59,12 @@ export class RiskSocketClient {
     this.clearReconnectTimer();
 
     const url = new URL(this.wsBaseUrl);
-    if (this.token) url.searchParams.set("token", this.token);
-
     const ws = new WebSocket(url.toString());
     this.ws = ws;
 
     ws.onopen = () => {
       this.reconnectAttempt = 0;
       this.emit({ event: "connected" });
-
-      if (this.token) {
-        this.safeSend({ type: "auth", payload: { token: this.token } });
-      }
 
       if (this.riskFeedEnabled) this.safeSend({ type: "subscribe", payload: { room: "risk:feed" } });
       for (const room of this.invoiceRooms) {


### PR DESCRIPTION
## Summary

Closes #242

Storing authentication tokens in `sessionStorage` exposes them to XSS — any injected script can read and exfiltrate the credential. This PR migrates off-chain auth to **server-set, HttpOnly cookies** so the token is invisible to JavaScript entirely.

- **`src/lib/httpClient.ts`** — removed `setAuthToken` / `getAuthToken` / `clearAuthToken` and the manual `Authorization: Bearer` interceptor. Added `withCredentials: true` so Axios instructs the browser to include the auth cookie automatically on every same-origin request.
- **`src/lib/riskSocket.ts`** — removed the `token` field from `RiskSocketClientOptions`, the `?token=…` query parameter on the WebSocket URL, and the `{ type: "auth" }` message sent on open. Browsers send cookies in the initial WebSocket upgrade handshake, so the server can authenticate from the cookie instead.
- **`src/app/api/auth/route.ts`** *(new)* — Next.js Route Handler with `POST` (accept a JWT → set `tradeflow_auth_token` cookie: `HttpOnly`, `Secure`, `SameSite=Strict`) and `DELETE` (expire the cookie, i.e. logout).
- **`jest.setup.js`** — wrapped `window`-specific mock code in `if (typeof window !== "undefined")` so the new route tests (which run in the `node` environment) don't crash.

## Test plan

- [ ] `src/lib/__tests__/httpClient.test.ts` *(new)* — verifies `withCredentials: true`, correct base-URL/timeout overrides, `X-Requested-With` header set, `Authorization` header absent.
- [ ] `src/app/api/auth/__tests__/route.test.ts` *(new)* — verifies `POST` sets `HttpOnly`, `SameSite=Strict`, `Path=/` cookie; rejects missing/empty token; rejects invalid JSON. Verifies `DELETE` expires the cookie via `Max-Age=0`.
- [ ] `src/lib/__tests__/riskSocket.test.ts` *(updated)* — asserts that `token=` no longer appears in the WebSocket URL.
- [ ] All pre-existing tests continue to pass (`npm test`).